### PR TITLE
Fix release uploads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Restore executable permissions
         run: |
-          chmod -R 755 Kiwi8.app
+          chmod -R u=rwx,go=rx Kiwi8.app
 
       - name: Create macOS release archive
         run: |


### PR DESCRIPTION
Ran into a strange issue that was difficult to resolve and caused me to go down several rabbit holes.


basically the release pipeline has to download the artifact (after uploading/zipped automatically) and so perhaps get lost during that apparently. so we just have to reapply the executable permissions recursively against the entire bundle.

this is NOT a code signing issue.